### PR TITLE
chore: migrate Renovate regex manager config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,9 @@
   "extends": [
     "config:recommended"
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["statefulset.yaml"], 
       "matchStrings": [
         "image:\\s(?<depName>.*):(?<currentValue>\\d+\\.\\d+\\.\\d+)"


### PR DESCRIPTION
## Summary
- migrate Renovate custom regex configuration from deprecated `regexManagers` to `customManagers`
- add `customType: "regex"` while preserving the existing file match, image parsing, automerge, and schedule settings

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`

This addresses the Renovate Dependency Dashboard config migration notice in #44.